### PR TITLE
Working with Nim 1.0

### DIFF
--- a/nsu.nimble
+++ b/nsu.nimble
@@ -7,4 +7,4 @@ srcDir = "src"
 bin = @["nsu"]
 
 # Dependencies
-requires "nim >= 0.17.2", "x11 >= 1.0.0", "png == 0.2.0"
+requires "nim >= 0.17.2", "x11 >= 1.0.0", "flippy == 0.4.0"

--- a/nsu.nimble
+++ b/nsu.nimble
@@ -7,4 +7,4 @@ srcDir = "src"
 bin = @["nsu"]
 
 # Dependencies
-requires "nim >= 0.17.2", "x11 >= 1.0.0", "oldwinapi >= 2.0.0", "png >= 0.2.0"
+requires "nim >= 0.17.2", "x11 >= 1.0.0", "png == 0.2.0"

--- a/nsu.nimble
+++ b/nsu.nimble
@@ -7,4 +7,4 @@ srcDir = "src"
 bin = @["nsu"]
 
 # Dependencies
-requires "nim >= 0.17.2", "x11 >= 1.0.0", "flippy == 0.4.0"
+requires "nim >= 0.17.2", "x11 >= 1.0.0", "winim >= 3.2.4", "flippy == 0.4.0"

--- a/src/nsupkg/nsu_types.nim
+++ b/src/nsupkg/nsu_types.nim
@@ -1,6 +1,6 @@
 
 when defined(Windows):
- from oldwinapi/windows import HWND
+ from winim import HWND
  type
   TSelVal* = tuple
    start_x, start_y, end_x, end_y: cint


### PR DESCRIPTION
This PR does the following: 
- Updates nsu to work with Nim 1.0
- Migrates from oldwinapi to winim
- Removes the dependency on the libpng.dll (replacing it with Flippy, a pure Nim library)
- Fixes a bug on Windows where high DPI displays weren't captured correctly